### PR TITLE
Use Launchy over MacOS `open`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in snapbot.gemspec
 gemspec
 
+gem "launchy", "~> 2.5.0"
+
 gem "rake", "~> 13.0"
 
 gem "rspec", "~> 3.0"

--- a/lib/snapbot/diagram.rb
+++ b/lib/snapbot/diagram.rb
@@ -2,7 +2,6 @@
 
 require "snapbot/diagram/dot_generator"
 require "snapbot/diagram/renderer"
-require "open3"
 
 module Snapbot
   # Print the small constellation of objects in your integration test and how they relate.
@@ -13,17 +12,19 @@ module Snapbot
       dot = DotGenerator.new(**args).dot
       filename = Renderer.new(dot).save
 
-      unless open_command.present?
-        warn "No `open` command available. File saved to #{filename}"
+      unless launchy_present?
+        warn "Cannot open diagram – install `launchy`. File saved to #{filename}"
         return
       end
 
-      _stdout, stderr, status = Open3.capture3("#{open_command} #{filename}")
-      raise stderr unless status.exitstatus.zero?
+      Launchy.open(Renderer::OUTPUT_FILENAME)
     end
 
-    def open_command
-      `which open`.chomp
+    def launchy_present?
+      require "launchy"
+      true
+    rescue LoadError
+      false
     end
   end
 end

--- a/snapbot.gemspec
+++ b/snapbot.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "activerecord", version_string
   spec.add_runtime_dependency "activesupport", version_string
 
+  spec.add_development_dependency "launchy"
   spec.add_development_dependency "rbs"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "steep"

--- a/spec/snapbot/diagram/manual_launch_spec.rb
+++ b/spec/snapbot/diagram/manual_launch_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "snapbot/diagram"
+
+RSpec.describe "a manual save_and_open_page", manual: true do
+  include FixtureDatabase
+  include Snapbot::Diagram
+
+  before { create_fixture_database }
+
+  it "can launch your browser", :manual do
+    save_and_open_diagram
+  end
+end

--- a/spec/snapbot/diagram_spec.rb
+++ b/spec/snapbot/diagram_spec.rb
@@ -1,36 +1,36 @@
 # frozen_string_literal: true
 
+require "launchy"
+
 RSpec.describe Snapbot::Diagram do
   describe ".save_and_open_diagram" do
     include Snapbot::Diagram
 
-    context "the command `open` exists" do
+    before { allow(Launchy).to receive(:open) }
+
+    context "Launchy is present" do
       before do
-        allow(self).to receive(:open_command).and_return("/usr/bin/fakeopencommand")
-        allow(Open3).to receive(:capture3).with(
-          "/usr/bin/fakeopencommand tmp/models.svg"
-        ).and_return(
-          ["", "", double("Process::Status", exitstatus: 0)]
-        )
+        allow(self).to receive(:launchy_present?).and_return(true)
       end
 
       it "saves and opens a diagram" do
         save_and_open_diagram
-        expect(Open3).to have_received(:capture3)
+        expect(Launchy).to have_received(:open).with("tmp/models.svg")
       end
     end
 
-    context "the command `open` does not exist" do
+    context "Launchy is not present" do
       before do
-        allow(self).to receive(:open_command).and_return("")
+        allow(self).to receive(:launchy_present?).and_return(false)
         allow(self).to receive(:warn)
-        allow(Open3).to receive(:capture3)
         save_and_open_diagram
       end
 
       it "only saves the diagram and warns about no `open`" do
-        expect(self).to have_received(:warn).with("No `open` command available. File saved to tmp/models.svg")
-        expect(Open3).not_to have_received(:capture3)
+        expect(self).to have_received(:warn).with(
+          "Cannot open diagram – install `launchy`. File saved to tmp/models.svg"
+        )
+        expect(Launchy).not_to have_received(:open)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,9 @@ RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 
+  # declare an exclusion filter
+  config.filter_run_excluding manual: true
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end


### PR DESCRIPTION
Stop pandering only to my personal use case and make this behave in most
respects identically to Capybara.

Add a manual_launch_spec that can just fire it up and check things for
real. Doesn't execute by default, it needs to be asked specifically.

Resolves #3 